### PR TITLE
US99231/ShadyImage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,9 @@
     "wct.conf.json"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#1 - 2"
+    "polymer": "Polymer/polymer#1 - 2",
+    "d2l-icons": "^5.0.2",
+    "d2l-colors": "^3.1.2"
   },
   "devDependencies": {
     "d2l-typography": "BrightspaceUI/typography#^6.0.0",

--- a/d2l-profile-image.html
+++ b/d2l-profile-image.html
@@ -1,4 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-icons/d2l-icon.html">
+<link rel="import" href="../d2l-icons/tier3-icons.html">
+
 
 <!--
 `d2l-profile-image`
@@ -10,19 +14,56 @@ D2L Profile Image
 	<template strip-whitespace>
 		<style>
 			:host {
+				display: none;
+			}
+			:host([small]) {
 				display: inline-block;
+				width: 30px;
+				height: 30px;
+				--d2l-icon-height: 30px;
+				--d2l-icon-width: 30px;
+				border-radius: 4px;
+				overflow: hidden;
+			}
+			:host([medium]) {
+				display: inline-block;
+				width: 42px;
+				height: 42px;
+				--d2l-icon-height: 42px;
+				--d2l-icon-width: 42px;
+				border-radius: 6px;
+				overflow: hidden;
+			}
+			:host([large]) {
+				display: inline-block;
+				width: 60px;
+				height: 60px;
+				--d2l-icon-height: 60px;
+				--d2l-icon-width: 60px;
+				border-radius: 8px;
+				overflow: hidden;
+			}
+			:host([x-large]) {
+				display: inline-block;
+				width: 84px;
+				height: 84px;
+				--d2l-icon-height: 84px;
+				--d2l-icon-width: 84px;
+				border-radius: 8px;
+				overflow: hidden;
+			}
+			.shady-person {
+				--d2l-icon-fill-color: var(--d2l-color-ferrite);
 			}
 		</style>
-		<h2>Hello [[prop1]]!</h2>
+		<div class="shady-person">
+			<d2l-icon icon="d2l-tier3:profile-pic"></d2l-icon>
+		</div>
 	</template>
 	<script>
 		Polymer({
 			is: 'd2l-profile-image',
 			properties: {
-				prop1: {
-					type: String,
-					value: 'd2l-profile-image',
-				}
 			}
 		});
 	</script>

--- a/d2l-profile-image.html
+++ b/d2l-profile-image.html
@@ -15,42 +15,31 @@ D2L Profile Image
 		<style>
 			:host {
 				display: none;
+				width: var(--size);
+				height: var(--size);
+				--d2l-icon-height: var(--size);
+				--d2l-icon-width: var(--size);
+				overflow: hidden;
 			}
 			:host([small]) {
 				display: inline-block;
-				width: 30px;
-				height: 30px;
-				--d2l-icon-height: 30px;
-				--d2l-icon-width: 30px;
+				--size: 30px;
 				border-radius: 4px;
-				overflow: hidden;
 			}
 			:host([medium]) {
 				display: inline-block;
-				width: 42px;
-				height: 42px;
-				--d2l-icon-height: 42px;
-				--d2l-icon-width: 42px;
+				--size: 42px;
 				border-radius: 6px;
-				overflow: hidden;
 			}
 			:host([large]) {
 				display: inline-block;
-				width: 60px;
-				height: 60px;
-				--d2l-icon-height: 60px;
-				--d2l-icon-width: 60px;
+				--size: 60px;
 				border-radius: 8px;
-				overflow: hidden;
 			}
 			:host([x-large]) {
 				display: inline-block;
-				width: 84px;
-				height: 84px;
-				--d2l-icon-height: 84px;
-				--d2l-icon-width: 84px;
+				--size: 84px;
 				border-radius: 8px;
-				overflow: hidden;
 			}
 			.shady-person {
 				--d2l-icon-fill-color: var(--d2l-color-ferrite);

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,22 @@
 			<h3>d2l-profile-image</h3>
 			<demo-snippet>
 				<template>
-					<d2l-profile-image></d2l-profile-image>
+
+					<d2l-profile-image ></d2l-profile-image>
+					<br/>
+
+					<d2l-profile-image small></d2l-profile-image>
+					<br/>
+
+					<d2l-profile-image medium></d2l-profile-image>
+					<br/>
+
+					<d2l-profile-image large></d2l-profile-image>
+					<br/>
+
+					<d2l-profile-image x-large></d2l-profile-image>
+					<br/>
+
 				</template>
 			</demo-snippet>
 		</div>

--- a/test/d2l-profile-image.html
+++ b/test/d2l-profile-image.html
@@ -9,17 +9,35 @@
 		<link rel="import" href="../d2l-profile-image.html">
 	</head>
 	<body>
-		<test-fixture id="basic">
+		<test-fixture id="d2l-profile-image-fixture">
 			<template>
 				<d2l-profile-image></d2l-profile-image>
 			</template>
 		</test-fixture>
 		<script>
 			suite('d2l-profile-image', function() {
-				test('instantiating the element works', function() {
-					var element = fixture('basic');
-					assert.equal(element.is, 'd2l-profile-image');
+
+				var element;
+
+				setup(function() {
+					element = fixture('d2l-profile-image-fixture');
 				});
+
+				// Specification can be found at
+				// http://design.d2l/components/profile-images/
+				[
+					{ size:'small', expectedLength: 30 },
+					{ size:'medium', expectedLength: 42 },
+					{ size:'large', expectedLength: 60 },
+					{ size:'x-large', expectedLength: 84 },
+				].forEach(function(testCase) {
+					test(testCase.size + ' profile image is sized according to spec', function() {
+						element.setAttribute(testCase.size, '');
+						assert.equal(element.offsetWidth, testCase.expectedLength);
+						assert.equal(element.offsetHeight, testCase.expectedLength);
+					});
+				});
+
 			});
 		</script>
 	</body>

--- a/test/d2l-profile-image.html
+++ b/test/d2l-profile-image.html
@@ -9,18 +9,36 @@
 		<link rel="import" href="../d2l-profile-image.html">
 	</head>
 	<body>
-		<test-fixture id="d2l-profile-image-fixture">
+		<test-fixture id="d2l-profile-image-fixture-small">
 			<template>
-				<d2l-profile-image></d2l-profile-image>
+				<d2l-profile-image small></d2l-profile-image>
+			</template>
+		</test-fixture>
+		<test-fixture id="d2l-profile-image-fixture-medium">
+			<template>
+				<d2l-profile-image medium></d2l-profile-image>
+			</template>
+		</test-fixture>
+		<test-fixture id="d2l-profile-image-fixture-large">
+			<template>
+				<d2l-profile-image large></d2l-profile-image>
+			</template>
+		</test-fixture>
+		<test-fixture id="d2l-profile-image-fixture-x-large">
+			<template>
+				<d2l-profile-image x-large></d2l-profile-image>
 			</template>
 		</test-fixture>
 		<script>
 			suite('d2l-profile-image', function() {
 
-				var element;
+				var sizes = ['small', 'medium', 'large', 'x-large'];
+				var elements = {};
 
 				setup(function() {
-					element = fixture('d2l-profile-image-fixture');
+					sizes.forEach(function(size) {
+						elements[size] = fixture('d2l-profile-image-fixture-' + size);
+					});
 				});
 
 				// Specification can be found at
@@ -32,7 +50,7 @@
 					{ size:'x-large', expectedLength: 84 },
 				].forEach(function(testCase) {
 					test(testCase.size + ' profile image is sized according to spec', function() {
-						element.setAttribute(testCase.size, '');
+						var element = elements[testCase.size];
 						assert.equal(element.offsetWidth, testCase.expectedLength);
 						assert.equal(element.offsetHeight, testCase.expectedLength);
 					});


### PR DESCRIPTION
* Rendering of ShadyImage
* This will be the default placeholder when 
  * If the user does not have a first or last name to display
  * If the user’s permission does not allow for the logged in user to view their name

http://design.d2l/components/profile-images/

I verified the visuals look correct on IE, Edge, Firefox, and Chrome.

Below I added background color to show the radius being applied.
The shady person image has even rounder boarder than the spec, so the rounded borders do not effect the shady person.

![image](https://user-images.githubusercontent.com/1176292/43908377-d7f73384-9bc5-11e8-89ef-f96c79a496c6.png)

~No explicit image was provided for the shady person, but it looks like it comes from the profile image in our icons repo. I applied the color that seemed appropriate to me.~

Confirmed image was correct with Bob, using the ferrite colour

![image](https://user-images.githubusercontent.com/1176292/43908402-e594b304-9bc5-11e8-9a4d-f4ccd5f59b34.png)
