### PR TITLE
Move host styling to shared

### DIFF
--- a/d2l-profile-image.html
+++ b/d2l-profile-image.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-icons/d2l-icon.html">
 <link rel="import" href="../d2l-icons/tier3-icons.html">
 
+<link rel="import" href="./src/d2l-profile-image-shared-styles.html">
 
 <!--
 `d2l-profile-image`
@@ -12,35 +13,7 @@ D2L Profile Image
 
 <dom-module id="d2l-profile-image">
 	<template strip-whitespace>
-		<style>
-			:host {
-				display: none;
-				width: var(--size);
-				height: var(--size);
-				--d2l-icon-height: var(--size);
-				--d2l-icon-width: var(--size);
-				overflow: hidden;
-			}
-			:host([small]) {
-				display: inline-block;
-				--size: 30px;
-				border-radius: 4px;
-			}
-			:host([medium]) {
-				display: inline-block;
-				--size: 42px;
-				border-radius: 6px;
-			}
-			:host([large]) {
-				display: inline-block;
-				--size: 60px;
-				border-radius: 8px;
-			}
-			:host([x-large]) {
-				display: inline-block;
-				--size: 84px;
-				border-radius: 8px;
-			}
+		<style include="d2l-profile-image-shared-styles">
 			.shady-person {
 				--d2l-icon-fill-color: var(--d2l-color-ferrite);
 			}

--- a/src/d2l-profile-image-shared-styles.html
+++ b/src/d2l-profile-image-shared-styles.html
@@ -1,0 +1,40 @@
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="d2l-profile-image-shared-styles">
+	<template>
+		<style>
+			:host {
+				display: none;
+				width: var(--size);
+				height: var(--size);
+				--d2l-icon-height: var(--size);
+				--d2l-icon-width: var(--size);
+				overflow: hidden;
+			}
+
+			:host([small]) {
+				display: inline-block;
+				--size: 30px;
+				border-radius: 4px;
+			}
+
+			:host([medium]) {
+				display: inline-block;
+				--size: 42px;
+				border-radius: 6px;
+			}
+
+			:host([large]) {
+				display: inline-block;
+				--size: 60px;
+				border-radius: 8px;
+			}
+
+			:host([x-large]) {
+				display: inline-block;
+				--size: 84px;
+				border-radius: 8px;
+			}
+		</style>
+	</template>
+</dom-module>


### PR DESCRIPTION
When trying to make the component hyper-media compatible I ran into styling issues with `IE` and `Edge`. I think it has something to do with style encapsulation and the shadow/shady DOM. This stackoverflow question is what helped me find the solution https://stackoverflow.com/questions/25468701/why-does-the-host-selector-only-work-in-chrome-with-platform-js. There are also a few Github issues around this topic. So I found to overcome this I had to duplicate the styling between the wrapper and base component. This is why I am splitting out the host styling portion.